### PR TITLE
utility function to invert color of hex color

### DIFF
--- a/__tests__/utils/invert-color-test.ts
+++ b/__tests__/utils/invert-color-test.ts
@@ -1,0 +1,256 @@
+import invert, { RGB, RgbArray, HexColor, BlackWhite } from '@/utils/invert-color'
+const { defaultThreshold } = invert
+
+/**
+ *  Test Suite
+ */
+describe('test: invert-color', () => {
+  const A_BLACK: RgbArray = [0, 0, 0]
+  const A_WHITE: RgbArray = [255, 255, 255]
+  const O_BLACK: RGB = { r: 0, g: 0, b: 0 }
+  const O_WHITE: RGB = { r: 255, g: 255, b: 255 }
+  const CUSTOM_BLACK: HexColor = '#303030'
+  const CUSTOM_WHITE: HexColor = '#fafafa'
+  const A_CUSTOM_BLACK: RgbArray = [48, 48, 48]
+  const O_CUSTOM_BLACK: RGB = { r: 48, g: 48, b: 48 }
+  const A_CUSTOM_WHITE: RgbArray = [250, 250, 250]
+  const O_CUSTOM_WHITE: RGB = { r: 250, g: 250, b: 250 }
+  const CUSTOM_BW_COLORS: BlackWhite = {
+    black: CUSTOM_BLACK,
+    white: CUSTOM_WHITE,
+  }
+
+  test('invert & match photoshop inverted colors', () => {
+    //            ORIGINAL            PHOTOSHOP
+    //            COLORS              INVERTED
+    // ---------------------------------------------
+    expect(invert('#201395')).toEqual('#dfec6a')
+    expect(invert('#840133')).toEqual('#7bfecc')
+    expect(invert('#6ec6c8')).toEqual('#913937')
+    expect(invert('#7fa1d3')).toEqual('#805e2c')
+    expect(invert('#e0c04e')).toEqual('#1f3fb1')
+    expect(invert('#3ad673')).toEqual('#c5298c')
+    expect(invert('#edffe7')).toEqual('#120018')
+    expect(invert('#a8f2f0')).toEqual('#570d0f')
+    expect(invert('#da6aaa')).toEqual('#259555')
+    expect(invert('#f9c6be')).toEqual('#063941')
+    expect(invert('#2c2ea2')).toEqual('#d3d15d')
+    expect(invert('#53456a')).toEqual('#acba95')
+    expect(invert('#ab1b77')).toEqual('#54e488')
+    expect(invert('#9288a4')).toEqual('#6d775b')
+    expect(invert('#cf4a78')).toEqual('#30b587')
+    expect(invert('#463069')).toEqual('#b9cf96')
+    expect(invert('#ac6d63')).toEqual('#53929c')
+    expect(invert('#be5a33')).toEqual('#41a5cc')
+    expect(invert('#a07c96')).toEqual('#5f8369')
+    expect(invert('#710cd1')).toEqual('#8ef32e')
+    expect(invert('#676693')).toEqual('#98996c')
+    expect(invert('#230be2')).toEqual('#dcf41d')
+    expect(invert('#9481a4')).toEqual('#6b7e5b')
+    expect(invert('#490cf8')).toEqual('#b6f307')
+    expect(invert('#389847')).toEqual('#c767b8')
+    expect(invert('#4898c2')).toEqual('#b7673d')
+    expect(invert('#71d449')).toEqual('#8e2bb6')
+    expect(invert('#61ad88')).toEqual('#9e5277')
+    expect(invert('#bd3a5b')).toEqual('#42c5a4')
+    expect(invert('#e32ac1')).toEqual('#1cd53e')
+    expect(invert('#ac3ba9')).toEqual('#53c456')
+    expect(invert('#c78ef0')).toEqual('#38710f')
+    expect(invert('#48bdda')).toEqual('#b74225')
+    expect(invert('#7855ae')).toEqual('#87aa51')
+    expect(invert('#bf9845')).toEqual('#4067ba')
+    expect(invert('#b2b766')).toEqual('#4d4899')
+    expect(invert('#6ca3d9')).toEqual('#935c26')
+    expect(invert('#b0af42')).toEqual('#4f50bd')
+    expect(invert('#9fec76')).toEqual('#601389')
+    expect(invert('#de79f1')).toEqual('#21860e')
+    expect(invert('#5b7b0a')).toEqual('#a484f5')
+    expect(invert('#27a5ec')).toEqual('#d85a13')
+    expect(invert('#a3375e')).toEqual('#5cc8a1')
+    expect(invert('#414176')).toEqual('#bebe89')
+    expect(invert('#cde92f')).toEqual('#3216d0')
+    expect(invert('#d13eb4')).toEqual('#2ec14b')
+    expect(invert('#ee7d54')).toEqual('#1182ab')
+    expect(invert('#35b9dc')).toEqual('#ca4623')
+    expect(invert('#bf137b')).toEqual('#40ec84')
+    expect(invert('#b7027c')).toEqual('#48fd83')
+    expect(invert('#000')).toEqual('#ffffff')
+    expect(invert('#fff')).toEqual('#000000')
+    expect(invert('#282b35')).toEqual('#d7d4ca')
+    expect(invert('#951a9d')).toEqual('#6ae562')
+    expect(invert('#566394')).toEqual('#a99c6b')
+  })
+
+  test('accept [r,g,b] or {r,g,b}', () => {
+    expect(invert([0, 0, 0])).toEqual('#ffffff')
+    expect(invert([255, 255, 255])).toEqual('#000000')
+    expect(invert([249, 119, 121])).toEqual('#068886')
+    expect(invert([69, 191, 189])).toEqual('#ba4042')
+    expect(invert([191, 19, 123])).toEqual('#40ec84')
+
+    expect(invert({ r: 0, g: 0, b: 0 })).toEqual('#ffffff')
+    expect(invert({ r: 255, g: 255, b: 255 })).toEqual('#000000')
+    expect(invert({ r: 249, g: 119, b: 121 })).toEqual('#068886')
+    expect(invert({ r: 69, g: 191, b: 189 })).toEqual('#ba4042')
+    expect(invert({ r: 191, g: 19, b: 123 })).toEqual('#40ec84')
+  })
+
+  test('invert to black or white', () => {
+    expect(invert('#631746', true)).toEqual('#ffffff')
+    expect(invert('#655c42', true)).toEqual('#ffffff')
+    expect(invert('#166528', true)).toEqual('#ffffff')
+    expect(invert('#4c2946', true)).toEqual('#ffffff')
+    expect(invert('#002d26', true)).toEqual('#ffffff')
+    expect(invert('#e71398', true)).toEqual('#000000')
+    expect(invert('#3ab3af', true)).toEqual('#000000')
+    expect(invert('#76ff98', true)).toEqual('#000000')
+    expect(invert('#bbb962', true)).toEqual('#000000')
+    expect(invert('#52838b', true)).toEqual('#000000')
+    expect(invert('#000', true)).toEqual('#ffffff')
+    expect(invert('#fff', true)).toEqual('#000000')
+    expect(invert('#ffffff', true)).toEqual('#000000')
+  })
+
+  test('invert to custom black and white colors', () => {
+    expect(invert('#631746', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE)
+    expect(invert('#655c42', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE)
+    expect(invert('#166528', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE)
+    expect(invert('#4c2946', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE)
+    expect(invert('#002d26', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE)
+    expect(invert('#e71398', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK)
+    expect(invert('#3ab3af', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK)
+    expect(invert('#76ff98', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK)
+    expect(invert('#bbb962', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK)
+    expect(invert('#52838b', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK)
+    expect(invert('#000', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE)
+    expect(invert('#fff', CUSTOM_BW_COLORS)).toEqual(CUSTOM_BLACK)
+  })
+
+  test('support true/false/object for black and white parameter', () => {
+    expect(invert('#201395', true)).toEqual('#ffffff')
+    expect(invert('#201395', false)).toEqual('#dfec6a')
+    expect(invert('#201395', CUSTOM_BW_COLORS)).toEqual(CUSTOM_WHITE)
+  })
+
+  test('invert to/from array/object to B/W', () => {
+    // this test also checks for object mutation
+
+    // hex as array
+    expect(invert.asRgbArray('#631746', true)).toEqual(A_WHITE)
+    expect(invert.asRgbArray('#655c42', true)).toEqual(A_WHITE)
+    expect(invert.asRgbArray('#e71398', true)).toEqual(A_BLACK)
+
+    expect(invert.asRgbArray('#282b35', false)).toEqual([215, 212, 202])
+
+    // hex as object
+    expect(invert.asRGB('#4c2946', true)).toEqual(O_WHITE)
+    expect(invert.asRGB('#002d26', true)).toEqual(O_WHITE)
+    expect(invert.asRGB('#76ff98', true)).toEqual(O_BLACK)
+
+    expect(invert.asRGB('#a8f2f0', false)).toEqual({ b: 15, g: 13, r: 87 })
+    expect(invert.asRGB('#282b35', false)).toEqual({ r: 215, g: 212, b: 202 })
+
+    // array as array
+    expect(invert.asRgbArray(A_WHITE, true)).toEqual(A_BLACK)
+    expect(invert.asRgbArray(A_BLACK, true)).toEqual(A_WHITE)
+
+    // object as array
+    expect(invert.asRgbArray(O_BLACK, true)).toEqual(A_WHITE)
+    expect(invert.asRgbArray(O_WHITE, true)).toEqual(A_BLACK)
+
+    // object as object
+    expect(invert.asRGB(O_BLACK, true)).toEqual(O_WHITE)
+    expect(invert.asRGB(O_WHITE, true)).toEqual(O_BLACK)
+  })
+
+  test('invert to/from array/object to custom B/W', () => {
+    // this test also checks for object mutation
+
+    // hex as array
+    expect(invert.asRgbArray('#631746', CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_WHITE)
+    expect(invert.asRgbArray('#655c42', CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_WHITE)
+    expect(invert.asRgbArray('#e71398', CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_BLACK)
+
+    // hex as object
+    expect(invert.asRGB('#4c2946', CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_WHITE)
+    expect(invert.asRGB('#002d26', CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_WHITE)
+    expect(invert.asRGB('#76ff98', CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_BLACK)
+
+    // array as array
+    expect(invert.asRgbArray(A_WHITE, CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_BLACK)
+    expect(invert.asRgbArray(A_BLACK, CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_WHITE)
+
+    // object as array
+    expect(invert.asRgbArray(O_BLACK, CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_WHITE)
+    expect(invert.asRgbArray(O_WHITE, CUSTOM_BW_COLORS)).toEqual(A_CUSTOM_BLACK)
+
+    // object as object
+    expect(invert.asRGB(O_BLACK, CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_WHITE)
+    expect(invert.asRGB(O_WHITE, CUSTOM_BW_COLORS)).toEqual(O_CUSTOM_BLACK)
+  })
+
+  test('invert to custom B/W with custom threshold', () => {
+    const color = '#929292'
+    const threshold = (t: number) =>
+      invert(color, { black: CUSTOM_BLACK, white: CUSTOM_WHITE, threshold: t })
+    const withDefaultThreshold = threshold(defaultThreshold)
+    expect(withDefaultThreshold).toEqual(invert(color, CUSTOM_BW_COLORS)) // no threshold defined
+    expect(withDefaultThreshold).toEqual(CUSTOM_BLACK)
+    expect(threshold(0)).toEqual(CUSTOM_BLACK)
+    expect(threshold(0.1)).toEqual(CUSTOM_BLACK)
+    expect(threshold(0.2)).toEqual(CUSTOM_BLACK)
+    expect(threshold(0.24)).toEqual(CUSTOM_BLACK)
+    expect(threshold(0.28)).toEqual(CUSTOM_BLACK)
+    expect(threshold(0.3)).toEqual(CUSTOM_WHITE)
+    expect(threshold(0.5)).toEqual(CUSTOM_WHITE)
+    expect(threshold(1)).toEqual(CUSTOM_WHITE)
+  })
+
+  test('modulo exceeding RGB comps', () => {
+    expect(invert([300, 300, 300])).toEqual('#2d2d2d')
+    expect(invert({ r: -46, g: -46, b: -46 })).toEqual('#2d2d2d')
+  })
+
+  test('throw on invalid hex', () => {
+    expect(() => {
+      invert('#')
+    }).toThrow()
+    expect(() => {
+      invert('12')
+    }).toThrow()
+    expect(() => {
+      invert('#ff')
+    }).toThrow()
+    expect(() => {
+      invert('#1234')
+    }).toThrow()
+    expect(() => {
+      invert('12345')
+    }).toThrow()
+    expect(() => {
+      invert('1234567')
+    }).toThrow()
+    expect(() => {
+      invert('1#3')
+    }).toThrow()
+    expect(() => {
+      invert('##631746', true)
+    }).toThrow()
+  })
+
+  test('throw on other invalid color values', () => {
+    expect(() => invert(null as any, true)).toThrow('Invalid color value')
+  })
+
+  test('not throw for valid hex with/out # prefix', () => {
+    expect(() => {
+      invert('123')
+    }).not.toThrow()
+    expect(() => {
+      invert('123456')
+    }).not.toThrow()
+    expect(() => {
+      invert('#aba')
+    }).not.toThrow()
+  })
+})

--- a/constants/Colors.ts
+++ b/constants/Colors.ts
@@ -7,6 +7,8 @@ const tintColorLight = '#0a7ea4'
 const tintColorDark = '#fff'
 
 export const Colors = {
+  black: '#000000',
+  white: '#ffffff',
   light: {
     text: '#11181C',
     background: '#fff',

--- a/utils/invert-color.ts
+++ b/utils/invert-color.ts
@@ -1,0 +1,175 @@
+// -------------------------------
+// TYPES / INTERFACES
+// -------------------------------
+
+/**
+ *  RGB object type with red, green and blue components.
+ */
+export type RGB = {
+  r: number
+  g: number
+  b: number
+}
+/**
+ *  RGB list (array) type with red, green and blue components.
+ */
+export type RgbArray = [number, number, number]
+/**
+ *  Hexadecimal representation of a color.
+ */
+export type HexColor = string
+/**
+ *  Color represented as hexadecimal value or as RGB object or list.
+ */
+export type Color = RGB | RgbArray | HexColor
+/**
+ *  Interface for defining black and white colors; used to amplify the contrast
+ *  of the color inversion.
+ */
+export interface BlackWhite {
+  black: HexColor
+  white: HexColor
+  threshold?: number
+}
+
+// -------------------------------
+// CONSTANTS
+// -------------------------------
+
+const DEFAULT_THRESHOLD = Math.sqrt(1.05 * 0.05) - 0.05
+const RE_HEX = /^(?:[0-9a-f]{3}){1,2}$/i
+const DEFAULT_BW: BlackWhite = {
+  black: '#000000',
+  white: '#ffffff',
+  threshold: DEFAULT_THRESHOLD,
+}
+
+// -------------------------------
+// HELPER METHODS
+// -------------------------------
+
+function padz(str: string, len: number = 2): string {
+  return (new Array(len).join('0') + str).slice(-len)
+}
+
+function hexToRgbArray(hex: string): RgbArray {
+  if (hex.slice(0, 1) === '#') hex = hex.slice(1)
+  if (!RE_HEX.test(hex)) throw new Error(`Invalid HEX color: "${hex}"`)
+  // normalize / convert 3-chars hex to 6-chars.
+  if (hex.length === 3) {
+    hex = hex[0] + hex[0] + hex[1] + hex[1] + hex[2] + hex[2]
+  }
+  return [
+    parseInt(hex.slice(0, 2), 16), // r
+    parseInt(hex.slice(2, 4), 16), // g
+    parseInt(hex.slice(4, 6), 16), // b
+  ]
+}
+
+function toRGB(c: RgbArray): RGB {
+  return { r: c[0], g: c[1], b: c[2] }
+}
+
+function toRgbArray(c: Color): RgbArray {
+  if (!c) throw new Error('Invalid color value')
+  if (Array.isArray(c)) return c as RgbArray
+  return typeof c === 'string' ? hexToRgbArray(c) : [c.r, c.g, c.b]
+}
+
+/**
+ * Reference: http://stackoverflow.com/a/3943023/112731
+ * Can use https://harthur.github.io/brain/ to train neural network to customize formula for lumniosity
+ */
+function getLuminance(c: RgbArray): number {
+  let i, x
+  const a = [] // so we don't mutate
+  for (i = 0; i < c.length; i++) {
+    x = c[i] / 255
+    a[i] = x <= 0.03928 ? x / 12.92 : Math.pow((x + 0.055) / 1.055, 2.4)
+  }
+  return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2]
+}
+
+function invertToBW(
+  color: RgbArray,
+  bw: BlackWhite | boolean,
+  asArr?: boolean,
+): RgbArray | HexColor {
+  const options = bw === true ? DEFAULT_BW : Object.assign({}, DEFAULT_BW, bw)
+  return getLuminance(color) > (options.threshold ?? DEFAULT_THRESHOLD)
+    ? asArr
+      ? hexToRgbArray(options.black)
+      : options.black
+    : asArr
+      ? hexToRgbArray(options.white)
+      : options.white
+}
+
+// -------------------------------
+// PUBLIC MEMBERS
+// -------------------------------
+
+/**
+ *  Generates inverted (opposite) version of the given color.
+ *  @param {Color} color - Color to be inverted.
+ *  @param {BlackWhite|boolean} [bw=false] - Whether to amplify the inversion to
+ *  black or white. Provide an object to customize black/white colors.
+ *  @returns {HexColor} - Hexadecimal representation of the inverted color.
+ */
+function invert(color: Color, bw: BlackWhite | boolean = false): HexColor {
+  color = toRgbArray(color)
+  if (bw) return invertToBW(color, bw) as HexColor
+  return '#' + color.map((c) => padz((255 - c).toString(16))).join('')
+}
+
+/**
+ *  Utility methods to generate inverted version of a color.
+ *  @namespace
+ */
+namespace invert {
+  /**
+   *  Generates inverted (opposite) version of the given color, as a RGB object.
+   *  @alias invert.asRgbObject
+   *  @param {Color} color - Color to be inverted.
+   *  @param {BlackWhite|boolean} [bw] - Whether to amplify the inversion to
+   *  black or white. Provide an object to customize black/white colors.
+   *  @returns {RGB} - RGB object representation of the inverted color.
+   */
+  export function asRGB(color: Color, bw?: BlackWhite | boolean): RGB {
+    color = toRgbArray(color)
+    const list: RgbArray = bw
+      ? (invertToBW(color, bw, true) as RgbArray)
+      : (color.map((c) => 255 - c) as RgbArray)
+    return toRGB(list)
+  }
+
+  /**
+   *  Generates inverted (opposite) version of the given color, as a RGB array.
+   *  @param {Color} color - Color to be inverted.
+   *  @param {BlackWhite|boolean} [bw] - Whether to amplify the inversion to
+   *  black or white. Provide an object to customize black/white colors.
+   *  @returns {RGB} - RGB array representation of the inverted color.
+   */
+  export function asRgbArray(color: Color, bw?: BlackWhite | boolean): RgbArray {
+    color = toRgbArray(color)
+    return bw ? (invertToBW(color, bw, true) as RgbArray) : (color.map((c) => 255 - c) as RgbArray)
+  }
+
+  /**
+   *  Default luminance threshold used for amplifying inversion to black and
+   *  white.
+   *  @type {number}
+   */
+  export const defaultThreshold = DEFAULT_THRESHOLD
+
+  /**
+   *  Alias of `.asRGB()`
+   */
+  export const asRgbObject = asRGB
+}
+
+// -------------------------------
+// EXPORT
+// -------------------------------
+
+export default invert

--- a/utils/invert-color.ts
+++ b/utils/invert-color.ts
@@ -1,3 +1,9 @@
+/**
+ * This utility is copied from https://github.com/onury/invert-color
+ * Does not violate their MIT license https://github.com/onury/invert-color/blob/master/LICENSE
+ * Copied the code instead of installing the package to avoid dependencies and unneeded bloating
+ */
+
 // -------------------------------
 // TYPES / INTERFACES
 // -------------------------------
@@ -108,6 +114,35 @@ function invertToBW(
 // -------------------------------
 // PUBLIC MEMBERS
 // -------------------------------
+
+/**Usage:
+ * invert('#000')              // —> #ffffff
+ * invert('#282b35')           // —> #d7d4ca
+ *
+ * // input color as RGB array or object
+ * invert([69, 191, 189])              // —> #ba4042
+ * invert({ r: 249, g: 119, b: 121 })  // —> #068886
+ *
+ * // amplify to black or white
+ * invert('#282b35', true)     // —> #ffffff
+ *
+ * // amplify to custom black or white color
+ * invert('#282b35', { black: '#3a3a3a', white: '#fafafa' })     // —> #fafafa
+ *
+ * // amplify with custom luminance threshold (default is invert.defaultThreshold = ~0.179)
+ * invert('#282b35', { black: '#3a3a3a', white: '#fafafa', threshold: 0.01 })     // —> #3a3a3a
+ *
+ * ### invert.asRGB(color[, bw])
+ * Invert and output result as RGB **object**.
+ * invert.asRGB('#fff')          // —> { r: 0, g: 0, b: 0 }
+ *
+ * ### `invert.asRgbArray(color[, bw])`
+ * Invert and output result as RGB **array**.
+ * invert.asRgbArray('#000')      // —> [255, 255, 255]
+ *
+ * ### bw option
+ * This is useful in case, you need to create contrast (i.e. background vs foreground, for better readability). The animation at the top is a demonstration.
+ */
 
 /**
  *  Generates inverted (opposite) version of the given color.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking
- [ ] Documentation Update

## What?

*Describe the purpose of this pull request, i.e. brief description.*

This is a utility function that returns the inverted color based on the input color. It also has the ability to return customized dark and light colors (defaults are black and white) depending on the inverted luminosity. This would be useful to generate contrasting colors for a more accessible UI, e.g. dark backgrounds with light text.

###Usage Example:

```
invert('#000')              // —> #ffffff
invert('#282b35')           // —> #d7d4ca

// input color as RGB array or object
invert([69, 191, 189])              // —> #ba4042
invert({ r: 249, g: 119, b: 121 })  // —> #068886

// amplify to black or white
invert('#282b35', true)     // —> #ffffff

// amplify to custom black or white color
invert('#282b35', { black: '#3a3a3a', white: '#fafafa' })     // —> #fafafa

// amplify with custom luminance threshold (default is invert.defaultThreshold = ~0.179)
invert('#282b35', { black: '#3a3a3a', white: '#fafafa', threshold: 0.01 })     // —> #3a3a3a
```

**`invert.asRGB(color[, bw])`**
Invert and output result as RGB **object**.

```
invert.asRGB('#fff')          // —> { r: 0, g: 0, b: 0 }
```

**`invert.asRgbArray(color[, bw])`**
Invert and output result as RGB **array**.

```
invert.asRgbArray('#000')      // —> [255, 255, 255]
```

**`bw` option**

 This is useful in case, you need to create contrast (i.e. background vs foreground, for better readability). The animation at the top is a demonstration.

## How?

*Describe the changes made, i.e. implementation details.*

-  This utility is copied from https://github.com/onury/invert-color
- Does not violate their MIT license https://github.com/onury/invert-color/blob/master/LICENSE
- Copied the code instead of installing the package to avoid dependencies and unneeded bloating

## Testing?

*Describe how the feature has been tested.*

| **Devices tested on** | **Code coverage** |
|-|-|
|iPhone 15 | invert-color.ts         \|     100 \|    96.87 \|     100 \|     100 \| 99)  |

Not sure why branch coverage is not 100% (pointing at line 99). I went through test cases and it handles every possible decision tree in line 99.

## Screenshots/Video (optional)

*Include screenshots or video demonstrating the new feature, if applicable.*

Will show use case for our app with the Avatar component that I am currently working on. But here is a snippet taken from the original creators to show the color inversion visually:
![Invert Animation](https://github.com/onury/invert-color/blob/master/test/anim/invert-animation.gif?raw=true)
