### PR TITLE
add avatar component

### DIFF
--- a/__tests__/components/Avatar/AvatarIcon-test.tsx
+++ b/__tests__/components/Avatar/AvatarIcon-test.tsx
@@ -1,0 +1,125 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import * as Avatar from '@/components/Avatar'
+import { Colors } from '@/constants/Colors'
+import invert from '@/utils/invert-color'
+import { AvatarSize } from '@/constants/Size'
+import VectorIcon from '@/components/VectorIcon'
+import { VectorIconProps } from '@/components/VectorIcon'
+
+// Mock the invert-color utility as a jest function
+jest.mock('@/utils/invert-color', () => jest.fn())
+// Mock the VectorIcon component
+jest.mock('@/components/VectorIcon', () => jest.fn())
+
+describe('Avatar Component', () => {
+  const defaultProps = {
+    icon: { name: 'user', type: 'FontAwesome', color: '#000' } as VectorIconProps,
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render with default props', () => {
+    ;(invert as unknown as jest.Mock).mockReturnValue('#ffffff')
+
+    const { getByTestId } = render(<Avatar.Icon testID="avatar-container" {...defaultProps} />)
+
+    const avatarContainer = getByTestId('avatar-container')
+
+    expect(avatarContainer).toBeTruthy()
+    expect(avatarContainer.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          width: AvatarSize.default,
+          height: AvatarSize.default,
+          backgroundColor: Colors.light.icon,
+          borderRadius: AvatarSize.default / 2,
+        }),
+      ]),
+    )
+
+    expect(VectorIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'user',
+        type: 'FontAwesome',
+        color: '#000',
+        size: AvatarSize.default * 0.6,
+      }),
+      {},
+    )
+  })
+
+  it('should apply custom size and color', () => {
+    const customSize = 48
+    const customColor = '#ff5733'
+
+    const { getByTestId } = render(
+      <Avatar.Icon
+        testID="avatar-container"
+        {...defaultProps}
+        size={customSize}
+        color={customColor}
+      />,
+    )
+
+    const avatarContainer = getByTestId('avatar-container')
+
+    expect(avatarContainer).toBeTruthy()
+    expect(avatarContainer.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          width: customSize,
+          height: customSize,
+          backgroundColor: customColor,
+          borderRadius: customSize / 2,
+        }),
+      ]),
+    )
+
+    expect(VectorIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'user',
+        type: 'FontAwesome',
+        color: '#000',
+        size: customSize * 0.6,
+      }),
+      {},
+    )
+
+    expect(invert).not.toHaveBeenCalled() // invert should not be called when icon color is provided
+  })
+
+  it('should apply custom container styles', () => {
+    const customStyle = { borderWidth: 2, borderColor: '#ff0000' }
+
+    const { getByTestId } = render(
+      <Avatar.Icon testID="avatar-container" {...defaultProps} style={customStyle} />,
+    )
+
+    const avatarContainer = getByTestId('avatar-container')
+
+    expect(avatarContainer.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(customStyle)]),
+    )
+  })
+
+  it('should apply inverted color when icon color is not provided', () => {
+    const customIcon = { name: 'user', type: 'FontAwesome' } as VectorIconProps
+
+    ;(invert as unknown as jest.Mock).mockReturnValue('#ffffff')
+
+    render(<Avatar.Icon icon={customIcon} />)
+
+    expect(VectorIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'user',
+        type: 'FontAwesome',
+        color: '#ffffff', // Color returned by invert
+      }),
+      {},
+    )
+    expect(invert).toHaveBeenCalledWith(Colors.light.icon, true)
+  })
+})

--- a/__tests__/components/Avatar/AvatarImage-test.tsx
+++ b/__tests__/components/Avatar/AvatarImage-test.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+import * as Avatar from '@/components/Avatar'
+import { AvatarSize } from '@/constants/Size'
+import { Image } from 'react-native'
+
+describe('Avatar.Image Component', () => {
+  const defaultProps = {
+    source: { uri: 'https://example.com/avatar.png' },
+  }
+
+  it('should render with default size and image source', () => {
+    const { getByTestId } = render(<Avatar.Image testID="avatar-container" {...defaultProps} />)
+
+    const avatarImage = getByTestId('avatar-container').children[0]
+
+    expect(avatarImage).toBeTruthy()
+    expect(avatarImage.props.source).toEqual(defaultProps.source)
+    expect(avatarImage.props.style).toEqual(
+      expect.objectContaining({
+        width: AvatarSize.default,
+        height: AvatarSize.default,
+        borderRadius: AvatarSize.default / 2,
+      }),
+    )
+  })
+
+  it('should render with a custom size', () => {
+    const customSize = 48
+    const { getByTestId } = render(
+      <Avatar.Image testID="avatar-container" {...defaultProps} size={customSize} />,
+    )
+
+    const avatarImage = getByTestId('avatar-container')
+
+    expect(avatarImage).toBeTruthy()
+    expect.arrayContaining([
+      expect.objectContaining({
+        width: customSize,
+        height: customSize,
+        borderRadius: customSize / 2,
+      }),
+    ])
+  })
+
+  it('should render with a functional source', () => {
+    const mockSource = jest
+      .fn()
+      .mockReturnValue(<Image source={{ uri: 'https://example.com/avatar2.png' }} />)
+    const { getByTestId } = render(<Avatar.Image testID="avatar-container" source={mockSource} />)
+
+    expect(mockSource).toHaveBeenCalledWith({ size: AvatarSize.default })
+    const avatarImage = getByTestId('avatar-container')
+    expect(avatarImage.children[0].props.source.uri).toBe('https://example.com/avatar2.png')
+  })
+
+  it('should apply custom styles to the container', () => {
+    const customStyle = { borderWidth: 2, borderColor: '#ff0000' }
+    const { getByTestId } = render(
+      <Avatar.Image testID="avatar-container" {...defaultProps} style={customStyle} />,
+    )
+
+    const avatarImage = getByTestId('avatar-container')
+    const avatarContainer = avatarImage.parent?.parent
+
+    expect(avatarContainer.props.style).toEqual(expect.objectContaining(customStyle))
+  })
+
+  it('should call onError callback on image load error', () => {
+    const mockOnError = jest.fn()
+    const { getByTestId } = render(
+      <Avatar.Image testID="avatar-container" {...defaultProps} onError={mockOnError} />,
+    )
+
+    const avatarImage = getByTestId('avatar-container').children[0]
+    fireEvent(avatarImage, 'error')
+
+    expect(mockOnError).toHaveBeenCalled()
+  })
+})

--- a/__tests__/components/Avatar/AvatarText-test.tsx
+++ b/__tests__/components/Avatar/AvatarText-test.tsx
@@ -1,0 +1,112 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import * as Avatar from '@/components/Avatar'
+import { Colors } from '@/constants/Colors'
+import invert from '@/utils/invert-color'
+import { AvatarSize } from '@/constants/Size'
+import { TextStyle } from 'react-native'
+
+// Mock the invert-color utility as a jest function
+jest.mock('@/utils/invert-color', () => jest.fn())
+
+describe('Avatar Component', () => {
+  const defaultProps = {
+    label: 'JD',
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should render with default props', () => {
+    const { getByText } = render(<Avatar.Text {...defaultProps} />)
+
+    const avatarText = getByText('JD')
+    const avatarContainer = avatarText.parent.parent
+
+    expect(avatarContainer).toBeTruthy()
+    expect(avatarText).toBeTruthy()
+    expect(avatarContainer.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          width: AvatarSize.default,
+          height: AvatarSize.default,
+          backgroundColor: Colors.light.icon,
+        }),
+      ]),
+    )
+    expect(invert).toHaveBeenCalledWith(Colors.light.icon, true)
+  })
+
+  it('should apply custom size and background color', () => {
+    const customSize = 48
+    const customBackgroundColor = '#000000'
+
+    // Here, we properly mock the return value of the invert function
+    ;(invert as unknown as jest.Mock).mockReturnValue('#ffffff')
+
+    const { getByText } = render(
+      <Avatar.Text {...defaultProps} size={customSize} backgroundColor={customBackgroundColor} />,
+    )
+
+    const avatarText = getByText('JD')
+    const avatarContainer = avatarText.parent.parent
+
+    expect(avatarContainer).toBeTruthy()
+    expect(avatarText).toBeTruthy()
+    expect(avatarContainer.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          width: customSize,
+          height: customSize,
+          backgroundColor: customBackgroundColor,
+        }),
+      ]),
+    )
+    expect(invert).toHaveBeenCalledWith(customBackgroundColor, true)
+    expect(avatarText.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          color: '#ffffff',
+          fontSize: customSize / 2,
+        }),
+      ]),
+    )
+  })
+
+  it('should apply custom label color', () => {
+    const customLabelColor = '#123456'
+
+    const { getByText } = render(<Avatar.Text {...defaultProps} labelColor={customLabelColor} />)
+
+    const avatarText = getByText('JD')
+
+    expect(avatarText.props.style).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          color: customLabelColor,
+        }),
+      ]),
+    )
+    expect(invert).not.toHaveBeenCalled() // invert should not be called when labelColor is provided
+  })
+
+  it('should apply custom styles for container and label', () => {
+    const customContainerStyle = { borderWidth: 2, borderColor: '#ff0000' }
+    const customLabelStyle: TextStyle = { fontWeight: 'bold' }
+
+    const { getByText } = render(
+      <Avatar.Text {...defaultProps} style={customContainerStyle} labelStyle={customLabelStyle} />,
+    )
+
+    const avatarText = getByText('JD')
+    const avatarContainer = avatarText.parent.parent
+
+    expect(avatarContainer.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(customContainerStyle)]),
+    )
+    expect(avatarText.props.style).toEqual(
+      expect.arrayContaining([expect.objectContaining(customLabelStyle)]),
+    )
+  })
+})

--- a/__tests__/components/VectorIcon-test.tsx
+++ b/__tests__/components/VectorIcon-test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import VectorIcon, { VectorIconProps } from '@/components/VectorIcon'
+import { Colors } from '@/constants/Colors'
+import { VectorIconSize } from '@/constants/Size'
+
+// Mocking all icon imports
+jest.mock('@expo/vector-icons/AntDesign', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/Entypo', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/EvilIcons', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/Feather', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/FontAwesome', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/FontAwesome5', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/FontAwesome6', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/Fontisto', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/Foundation', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/Ionicons', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/MaterialCommunityIcons', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/MaterialIcons', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/Octicons', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/SimpleLineIcons', () => ({ default: jest.fn(() => null) }))
+jest.mock('@expo/vector-icons/Zocial', () => ({ default: jest.fn(() => null) }))
+
+describe('VectorIcon Component', () => {
+  const defaultProps: VectorIconProps = {
+    name: 'user',
+  }
+
+  it.each`
+    type                        | mockedIcon
+    ${'AntDesign'}              | ${require('@expo/vector-icons/AntDesign').default}
+    ${'Entypo'}                 | ${require('@expo/vector-icons/Entypo').default}
+    ${'EvilIcons'}              | ${require('@expo/vector-icons/EvilIcons').default}
+    ${'Feather'}                | ${require('@expo/vector-icons/Feather').default}
+    ${'FontAwesome'}            | ${require('@expo/vector-icons/FontAwesome').default}
+    ${'FontAwesome5'}           | ${require('@expo/vector-icons/FontAwesome5').default}
+    ${'FontAwesome6'}           | ${require('@expo/vector-icons/FontAwesome6').default}
+    ${'Fontisto'}               | ${require('@expo/vector-icons/Fontisto').default}
+    ${'Foundation'}             | ${require('@expo/vector-icons/Foundation').default}
+    ${'Ionicons'}               | ${require('@expo/vector-icons/Ionicons').default}
+    ${'MaterialCommunityIcons'} | ${require('@expo/vector-icons/MaterialCommunityIcons').default}
+    ${'MaterialIcons'}          | ${require('@expo/vector-icons/MaterialIcons').default}
+    ${'Octicons'}               | ${require('@expo/vector-icons/Octicons').default}
+    ${'SimpleLineIcons'}        | ${require('@expo/vector-icons/SimpleLineIcons').default}
+    ${'Zocial'}                 | ${require('@expo/vector-icons/Zocial').default}
+  `('renders $type icon correctly', ({ type, mockedIcon }) => {
+    render(<VectorIcon {...defaultProps} type={type} />)
+    expect(mockedIcon).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'user',
+        size: VectorIconSize.default,
+        color: Colors.light.icon,
+      }),
+      {},
+    )
+  })
+
+  it('renders with default props', () => {
+    const MaterialIcons = require('@expo/vector-icons/MaterialIcons').default
+    render(<VectorIcon {...defaultProps} />)
+    expect(MaterialIcons).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'user',
+        size: VectorIconSize.default,
+        color: Colors.light.icon,
+      }),
+      {},
+    )
+  })
+
+  it('renders with custom size and color', () => {
+    const customProps: VectorIconProps = {
+      name: 'user',
+      size: 32,
+      color: '#ff0000',
+    }
+    const MaterialIcons = require('@expo/vector-icons/MaterialIcons').default
+    render(<VectorIcon {...customProps} />)
+    expect(MaterialIcons).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'user',
+        size: 32,
+        color: '#ff0000',
+      }),
+      {},
+    )
+  })
+
+  it('renders with invalid type using default MaterialIcons', () => {
+    const MaterialIcons = require('@expo/vector-icons/MaterialIcons').default
+    render(<VectorIcon {...defaultProps} type={'InvalidType' as any} />)
+    expect(MaterialIcons).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'user',
+        size: VectorIconSize.default,
+        color: Colors.light.icon,
+      }),
+      {},
+    )
+  })
+})

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,7 +1,7 @@
 import { Tabs } from 'expo-router'
 
 import { Colors } from '@/constants/Colors'
-import TabBarIcon from '@/components/TabBarIcon'
+import VectorIcon from '@/components/VectorIcon'
 
 const TabLayout = () => {
   return (
@@ -11,7 +11,7 @@ const TabLayout = () => {
         options={{
           headerShown: false,
           title: 'Home',
-          tabBarIcon: ({ color }) => <TabBarIcon name="home" color={color} />,
+          tabBarIcon: ({ color }) => <VectorIcon name="home" color={color} />,
         }}
       />
       <Tabs.Screen
@@ -19,7 +19,7 @@ const TabLayout = () => {
         options={{
           headerShown: false,
           title: 'Create',
-          tabBarIcon: ({ color }) => <TabBarIcon name="add-circle-outline" color={color} />,
+          tabBarIcon: ({ color }) => <VectorIcon name="add-circle-outline" color={color} />,
         }}
       />
       <Tabs.Screen
@@ -27,7 +27,7 @@ const TabLayout = () => {
         options={{
           headerShown: false,
           title: 'Reels',
-          tabBarIcon: ({ color }) => <TabBarIcon name="album" color={color} />,
+          tabBarIcon: ({ color }) => <VectorIcon name="album" color={color} />,
         }}
       />
       <Tabs.Screen
@@ -35,7 +35,7 @@ const TabLayout = () => {
         options={{
           headerShown: false,
           title: 'Profile',
-          tabBarIcon: ({ color }) => <TabBarIcon name="account-circle" color={color} />,
+          tabBarIcon: ({ color }) => <VectorIcon name="account-circle" color={color} />,
         }}
       />
     </Tabs>

--- a/app/(tabs)/home/_layout.tsx
+++ b/app/(tabs)/home/_layout.tsx
@@ -1,7 +1,7 @@
 import { Stack } from 'expo-router'
 
 import { Colors } from '@/constants/Colors'
-import TabBarIcon from '@/components/TabBarIcon'
+import VectorIcon from '@/components/VectorIcon'
 import TabBarLink from '@/components/TabBarLink'
 
 const HomeLayout = () => {
@@ -13,12 +13,12 @@ const HomeLayout = () => {
           title: 'Home',
           headerLeft: () => (
             <TabBarLink href="/home/settings">
-              <TabBarIcon name="settings" color={Colors.light.tabIconSelected} />
+              <VectorIcon name="settings" color={Colors.light.tabIconSelected} />
             </TabBarLink>
           ),
           headerRight: () => (
             <TabBarLink href="/home/messages">
-              <TabBarIcon name="message" color={Colors.light.tabIconSelected} />
+              <VectorIcon name="message" color={Colors.light.tabIconSelected} />
             </TabBarLink>
           ),
         }}

--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -1,69 +1,14 @@
-import { Text, ImageSourcePropType, View, StyleSheet } from 'react-native'
+import { Text } from 'react-native'
 import React from 'react'
 
 import TabSafeAreaView from '@/components/TabSafeAreaView'
-import * as Avatar from '@/components/Avatar'
-import icon from '@/assets/images/icon.png'
-import splash from '@/assets/images/splash.png'
-import { Colors } from '@/constants/Colors'
 
 const Home = () => {
-  const handleOnError = () => {
-    return (
-      <Avatar.Icon
-        color="#3df"
-        icon={{ name: 'dog', type: 'MaterialCommunityIcons', color: 'yellow' }}
-      />
-    )
-  }
-
   return (
     <TabSafeAreaView>
       <Text>Home</Text>
-      <View style={styles.container}>
-        <Avatar.Text label="JF" />
-        <Avatar.Text label="JF" size={25} backgroundColor={Colors.light.tabIconSelected} />
-        <Avatar.Text
-          label="JF"
-          size={100}
-          backgroundColor={Colors.white}
-          labelColor={Colors.light.tint}
-        />
-      </View>
-      <View style={styles.container}>
-        <Avatar.Icon
-          color="#945"
-          icon={{ name: 'dog', type: 'MaterialCommunityIcons', color: 'yellow' }}
-          size={200}
-        />
-        <Avatar.Icon
-          color="#ff9"
-          icon={{ name: 'meh', type: 'AntDesign', color: 'brown' }}
-          size={80}
-        />
-        <Avatar.Icon color="navy" icon={{ name: 'bug', type: 'Entypo', color: 'red' }} size={40} />
-      </View>
-      <View style={styles.container}>
-        <Avatar.Image source={icon} size={120} />
-        <Avatar.Image source={splash} size={120} />
-        <Avatar.Image
-          size={120}
-          source={{
-            uri: 'https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExejcxcmI2cmJmaXF5aGN4ejVsb3BmaGhhYWpldmppMWM3NzJibDhhaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VbnUQpnihPSIgIXuZv/giphy.gif',
-          }}
-        />
-      </View>
     </TabSafeAreaView>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-evenly',
-    marginBottom: 20,
-  },
-})
 
 export default Home

--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -1,14 +1,69 @@
-import { Text } from 'react-native'
+import { Text, ImageSourcePropType, View, StyleSheet } from 'react-native'
 import React from 'react'
 
 import TabSafeAreaView from '@/components/TabSafeAreaView'
+import * as Avatar from '@/components/Avatar'
+import icon from '@/assets/images/icon.png'
+import splash from '@/assets/images/splash.png'
+import { Colors } from '@/constants/Colors'
 
 const Home = () => {
+  const handleOnError = () => {
+    return (
+      <Avatar.Icon
+        color="#3df"
+        icon={{ name: 'dog', type: 'MaterialCommunityIcons', color: 'yellow' }}
+      />
+    )
+  }
+
   return (
     <TabSafeAreaView>
       <Text>Home</Text>
+      <View style={styles.container}>
+        <Avatar.Text label="JF" />
+        <Avatar.Text label="JF" size={25} backgroundColor={Colors.light.tabIconSelected} />
+        <Avatar.Text
+          label="JF"
+          size={100}
+          backgroundColor={Colors.white}
+          labelColor={Colors.light.tint}
+        />
+      </View>
+      <View style={styles.container}>
+        <Avatar.Icon
+          color="#945"
+          icon={{ name: 'dog', type: 'MaterialCommunityIcons', color: 'yellow' }}
+          size={200}
+        />
+        <Avatar.Icon
+          color="#ff9"
+          icon={{ name: 'meh', type: 'AntDesign', color: 'brown' }}
+          size={80}
+        />
+        <Avatar.Icon color="navy" icon={{ name: 'bug', type: 'Entypo', color: 'red' }} size={40} />
+      </View>
+      <View style={styles.container}>
+        <Avatar.Image source={icon} size={120} />
+        <Avatar.Image source={splash} size={120} />
+        <Avatar.Image
+          size={120}
+          source={{
+            uri: 'https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExejcxcmI2cmJmaXF5aGN4ejVsb3BmaGhhYWpldmppMWM3NzJibDhhaiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VbnUQpnihPSIgIXuZv/giphy.gif',
+          }}
+        />
+      </View>
     </TabSafeAreaView>
   )
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-evenly',
+    marginBottom: 20,
+  },
+})
 
 export default Home

--- a/components/Avatar/AvatarIcon.tsx
+++ b/components/Avatar/AvatarIcon.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react'
+import { StyleProp, StyleSheet, View, ViewStyle } from 'react-native'
+import VectorIcon, { VectorIconProps } from '../VectorIcon'
+import { Colors } from '@/constants/Colors'
+import invert from '@/utils/invert-color'
+import { AvatarSize } from '@/constants/Size'
+
+type Props = React.ComponentPropsWithRef<typeof View> & {
+  /**
+   * Icon to display for the `Avatar`.
+   */
+  icon: VectorIconProps
+  /**
+   * Size of the avatar.
+   */
+  size?: number
+  /**
+   * Custom color for the container.
+   */
+  color?: string
+  /**
+   * Style for the container
+   */
+  style?: StyleProp<ViewStyle>
+}
+
+/**
+ * Avatars can be used to represent people in a graphical way.
+ *
+ * ## Usage
+ * ```
+ * import * as React from 'react';
+ * import { Avatar } from 'react-native-paper';
+ *
+ * const MyComponent = () => (
+ *   <Avatar.Icon size={24} />
+ * );
+ * ```
+ */
+const Avatar = ({ icon, size = AvatarSize.default, color, style, ...rest }: Props) => {
+  const backgroundColor = color ?? Colors.light.icon
+  const { ...restStyle } = StyleSheet.flatten(style) || {}
+  return (
+    <View
+      style={[
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor,
+        },
+        styles.container,
+        restStyle,
+      ]}
+      {...rest}>
+      <VectorIcon
+        name={icon.name}
+        type={icon.type}
+        color={icon.color ?? invert(backgroundColor, true)}
+        size={size * 0.6}
+      />
+    </View>
+  )
+}
+
+Avatar.displayName = 'Avatar.Icon'
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+})
+
+export default Avatar

--- a/components/Avatar/AvatarImage.tsx
+++ b/components/Avatar/AvatarImage.tsx
@@ -1,0 +1,71 @@
+import {
+  View,
+  Image,
+  ImageSourcePropType,
+  StyleProp,
+  ViewStyle,
+  ImageProps,
+  StyleSheet,
+} from 'react-native'
+import React from 'react'
+import { AvatarSize } from '@/constants/Size'
+
+type AvatarImageSource = ImageSourcePropType | ((props: { size: number }) => React.ReactNode)
+
+type Props = React.ComponentPropsWithRef<typeof View> & {
+  /**
+   * Image to display for the `Avatar`.
+   * It accepts a standard React Native Image `source` prop
+   * Or a function that returns an `Image`.
+   */
+  source: AvatarImageSource
+  /**
+   * Size of the avatar.
+   */
+  size?: number
+  /**
+   * Style for the container
+   */
+  style?: StyleProp<ViewStyle>
+  /**
+   * Invoked on load error.
+   */
+  onError?: ImageProps['onError']
+}
+
+const Avatar = ({ source, size = AvatarSize.default, style, onError, ...rest }: Props) => {
+  const { ...restStyle } = StyleSheet.flatten(style) || {}
+  return (
+    <View
+      style={[
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+        },
+        styles.container,
+        restStyle,
+      ]}
+      {...rest}>
+      {typeof source === 'function' && source({ size })}
+      {typeof source !== 'function' && (
+        <Image
+          source={source}
+          style={{ width: size, height: size, borderRadius: size / 2 }}
+          onError={onError}
+          accessibilityIgnoresInvertColors></Image>
+      )}
+    </View>
+  )
+}
+
+Avatar.displayName = 'Avatar.Image'
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+})
+
+export default Avatar

--- a/components/Avatar/AvatarText.tsx
+++ b/components/Avatar/AvatarText.tsx
@@ -1,0 +1,114 @@
+import {
+  View,
+  Text,
+  StyleSheet,
+  StyleProp,
+  ViewStyle,
+  TextStyle,
+  useWindowDimensions,
+} from 'react-native'
+import React from 'react'
+import { Colors } from '@/constants/Colors'
+import invert from '@/utils/invert-color'
+import { AvatarSize } from '@/constants/Size'
+
+type Props = React.ComponentPropsWithRef<typeof View> & {
+  /**
+   * Initials to show as the text in the `Avatar`.
+   */
+  label: string
+  /**
+   * Size of the avatar.
+   */
+  size?: number
+  /**
+   * Custom color for the text.
+   */
+  labelColor?: string
+  /**
+   * Style for the title.
+   */
+  labelStyle?: StyleProp<TextStyle>
+  /*
+   * Custom color for the container
+   */
+  backgroundColor?: string
+  /**
+   * Style for the container
+   */
+  style?: StyleProp<ViewStyle>
+}
+
+/**
+ * Avatars can be used to represent people in a graphical way.
+ *
+ * ## Usage
+ * ```
+ * import * as React from 'react';
+ * import * as Avatar from '@/components/Avatar'
+ *
+ * const MyComponent = () => (
+ *   <Avatar.Text size={24} label="XD" />
+ * );
+ * ```
+ */
+const Avatar = ({
+  label,
+  size = AvatarSize.default,
+  style,
+  labelColor: customLabelColor,
+  labelStyle,
+  backgroundColor: customBackgroundColor,
+  ...rest
+}: Props) => {
+  /**
+   * TODO: With ThemeProvider, colors (backgroundColor and textColor) should be taken with Theme context
+   */
+  const backgroundColor = customBackgroundColor ?? Colors.light.icon
+  const textColor = customLabelColor ?? invert(backgroundColor, true)
+  const { ...restStyle } = StyleSheet.flatten(style) || {}
+  const { fontScale } = useWindowDimensions()
+  return (
+    <View
+      style={[
+        {
+          width: size,
+          height: size,
+          borderRadius: size / 2,
+          backgroundColor,
+        },
+        styles.container,
+        restStyle,
+      ]}
+      {...rest}>
+      <Text
+        style={[
+          styles.text,
+          {
+            color: textColor,
+            fontSize: size / 2,
+            lineHeight: size / fontScale,
+          },
+          labelStyle,
+        ]}
+        numberOfLines={1}>
+        {label}
+      </Text>
+    </View>
+  )
+}
+
+Avatar.displayName = 'Avatar.Text'
+
+const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  text: {
+    textAlign: 'center',
+    textAlignVertical: 'center',
+  },
+})
+
+export default Avatar

--- a/components/Avatar/index.tsx
+++ b/components/Avatar/index.tsx
@@ -1,0 +1,8 @@
+// @component ./AvatarIcon.tsx
+export { default as Icon } from './AvatarIcon'
+
+// @component ./AvatarImage.tsx
+export { default as Image } from './AvatarImage'
+
+// @component ./AvatarText.tsx
+export { default as Text } from './AvatarText'

--- a/components/VectorIcon.tsx
+++ b/components/VectorIcon.tsx
@@ -1,0 +1,120 @@
+import React from 'react'
+import { Colors } from '@/constants/Colors'
+import { IconProps } from '@expo/vector-icons/build/createIconSet'
+import { VectorIconSize } from '@/constants/Size'
+
+export interface VectorIconProps extends IconProps<string> {
+  /**
+   * See available icon types at https://icons.expo.fyi/Index
+   */
+  type?:
+    | 'AntDesign'
+    | 'Entypo'
+    | 'EvilIcons'
+    | 'Feather'
+    | 'FontAwesome'
+    | 'FontAwesome5'
+    | 'FontAwesome6'
+    | 'Fontisto'
+    | 'Foundation'
+    | 'Ionicons'
+    | 'MaterialCommunityIcons'
+    | 'MaterialIcons'
+    | 'Octicons'
+    | 'SimpleLineIcons'
+    | 'Zocial'
+  name: string
+  size?: number
+  color?: string
+}
+
+const VectorIcon = ({
+  type = 'MaterialIcons',
+  name,
+  size = VectorIconSize.default,
+  color = Colors.light.icon,
+}: VectorIconProps) => {
+  switch (type) {
+    case 'AntDesign': {
+      const AntDesign = require('@expo/vector-icons/AntDesign').default
+      return <AntDesign name={name} size={size} color={color} />
+    }
+
+    case 'Entypo': {
+      const Entypo = require('@expo/vector-icons/Entypo').default
+      return <Entypo name={name} size={size} color={color} />
+    }
+
+    case 'EvilIcons': {
+      const EvilIcons = require('@expo/vector-icons/EvilIcons').default
+      return <EvilIcons name={name} size={size} color={color} />
+    }
+
+    case 'Feather': {
+      const Feather = require('@expo/vector-icons/Feather').default
+      return <Feather name={name} size={size} color={color} />
+    }
+
+    case 'FontAwesome': {
+      const FontAwesome = require('@expo/vector-icons/FontAwesome').default
+      return <FontAwesome name={name} size={size} color={color} />
+    }
+
+    case 'FontAwesome5': {
+      const FontAwesome5 = require('@expo/vector-icons/FontAwesome5').default
+      return <FontAwesome5 name={name} size={size} color={color} />
+    }
+
+    case 'FontAwesome6': {
+      const FontAwesome6 = require('@expo/vector-icons/FontAwesome6').default
+      return <FontAwesome6 name={name} size={size} color={color} />
+    }
+
+    case 'Fontisto': {
+      const Fontisto = require('@expo/vector-icons/Fontisto').default
+      return <Fontisto name={name} size={size} color={color} />
+    }
+
+    case 'Foundation': {
+      const Foundation = require('@expo/vector-icons/Foundation').default
+      return <Foundation name={name} size={size} color={color} />
+    }
+
+    case 'Ionicons': {
+      const Ionicons = require('@expo/vector-icons/Ionicons').default
+      return <Ionicons name={name} size={size} color={color} />
+    }
+
+    case 'MaterialCommunityIcons': {
+      const MaterialCommunityIcons = require('@expo/vector-icons/MaterialCommunityIcons').default
+      return <MaterialCommunityIcons name={name} size={size} color={color} />
+    }
+
+    case 'MaterialIcons': {
+      const MaterialIcons = require('@expo/vector-icons/MaterialIcons').default
+      return <MaterialIcons name={name} size={size} color={color} />
+    }
+
+    case 'Octicons': {
+      const Octicons = require('@expo/vector-icons/Octicons').default
+      return <Octicons name={name} size={size} color={color} />
+    }
+
+    case 'SimpleLineIcons': {
+      const SimpleLineIcons = require('@expo/vector-icons/SimpleLineIcons').default
+      return <SimpleLineIcons name={name} size={size} color={color} />
+    }
+
+    case 'Zocial': {
+      const Zocial = require('@expo/vector-icons/Zocial').default
+      return <Zocial name={name} size={size} color={color} />
+    }
+
+    default: {
+      const MaterialIcons = require('@expo/vector-icons/MaterialIcons').default
+      return <MaterialIcons name={name} size={size} color={color} />
+    }
+  }
+}
+
+export default VectorIcon

--- a/constants/Size.ts
+++ b/constants/Size.ts
@@ -1,0 +1,7 @@
+export const AvatarSize = {
+  default: 64,
+}
+
+export const VectorIconSize = {
+  default: 28,
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,5 +6,5 @@
       "@/*": ["./*"]
     }
   },
-  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts"]
+  "include": ["**/*.ts", "**/*.tsx", ".expo/types/**/*.ts", "expo-env.d.ts", "index.d.ts"]
 }

--- a/types/images.d.ts
+++ b/types/images.d.ts
@@ -1,0 +1,56 @@
+// images
+declare module '*.png' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.jpg' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.jpeg' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.jfif' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.pjpeg' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.pjp' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.gif' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.svg' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.ico' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.webp' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}
+declare module '*.avif' {
+  import { ImageSourcePropType } from 'react-native'
+  const src: ImageSourcePropType
+  export default src
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking
- [ ] Documentation Update

## What?

*Describe the purpose of this pull request, i.e. brief description.*

This creates the Avatar component and the VectorIcon component.

### VectorIcon

TLDR: The `VectorIcon` component is essentially a wrapper around Expo Vector Icons. This allows us to need to use only 1 component for Icons (if the icons are a part of the expo vector icon family).

For example:
- Before to use expo's vector icons, you would have to import the specific icon family: 
```
import Ionicons from '@expo/vector-icons/Ionicons'
<Ionicons name="checkmark-circle" size={32} color="green" />
```
- Now you can pass in the family and name of the icon as a prop:
```
import VectorIcon from '@/components/VectorIcon'
<VectorIcon name="checkmark-circle" type="Ionicons" size={32} color="green" />
```

The component supports all currently available vector families offered by Expo. The component's props is an extension of the Expo's `IconProps<T>` which means all available props of the original Icon remains.

### Avatar

TLDR: The `Avatar` component is to be used mainly for the profile circles seen in most standard applications.

This component can take in and display Text, Icons or Image as part of the Avatar (screenshots below). There is actually three different sub-components to handle this:

- Avatar.Text: display initials
- Avatar.Icon: display an icon
- Avatar.Image: display an image

## How?

*Describe the changes made, i.e. implementation details.*

### VectorIcon

Implementation is straightforward - depending on the family and icon name, it will generate the respective icon from the Expo Vector family. This does mean that if you use a name non-existant in a particular family, the component will throw an error.

### Avatar

Avatar is essentially a glorified circle that displays either a passed in text, icon or image. The Avatar.Icon uses VectorIcons behind the scenes. If we want to later use our own icons, then it can be extended - but leaving this as a future dev work. The Avatar.Image can use either a local resource or a remote url with the`{{uri: ...}}` prop. It is the same source as a native React Image element.

## Testing?

*Describe how the feature has been tested.*

| **Devices tested on** | **Code coverage** |
|-|-|
| iPhone11, iPhone15 | <img width="506" alt="Screenshot 2024-08-19 at 6 19 01 PM" src="https://github.com/user-attachments/assets/58baa04b-9144-4246-8f29-d2160e6ec37b"> |

`components/Avatar/index.js` just handles group exporting the Avatar component so doesn't require testing.

## Screenshots/Video (optional)

*Include screenshots or video demonstrating the new feature, if applicable.*

Hard to see but the cat photo is actually a gif (yea it support gifs xD)

<img width="300" src="https://github.com/user-attachments/assets/3d744548-4b1a-4958-8f0a-0c7ccebdc8a5" />


