### PR TITLE
create focusawarestatusbar

### DIFF
--- a/__tests__/components/FocusAwareStatusBar-test.tsx
+++ b/__tests__/components/FocusAwareStatusBar-test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import { useIsFocused } from '@react-navigation/native'
+import FocusAwareStatusBar from '@/components/FocusAwareStatusBar'
+import { View } from 'react-native'
+
+// Mock the useIsFocused hook
+jest.mock('@react-navigation/native', () => ({
+  useIsFocused: jest.fn(),
+}))
+
+describe('FocusAwareStatusBar', () => {
+  it('should render StatusBar when the screen is focused', () => {
+    // Mock useIsFocused to return true
+    ;(useIsFocused as jest.Mock).mockReturnValue(true)
+
+    const { getByTestId } = render(
+      <View testID="focus-aware-status-bar">
+        <FocusAwareStatusBar />
+      </View>,
+    )
+
+    // Check if the StatusBar is rendered
+    expect(getByTestId('focus-aware-status-bar').children[0]).toBeTruthy()
+  })
+
+  it('should not render StatusBar when the screen is not focused', () => {
+    // Mock useIsFocused to return false
+    ;(useIsFocused as jest.Mock).mockReturnValue(false)
+
+    const { getByTestId } = render(
+      <View testID="focus-aware-status-bar">
+        <FocusAwareStatusBar />
+      </View>,
+    )
+
+    // Check if the StatusBar is not rendered
+    expect(getByTestId('focus-aware-status-bar').child).toBeUndefined()
+  })
+})

--- a/components/FocusAwareStatusBar.tsx
+++ b/components/FocusAwareStatusBar.tsx
@@ -1,0 +1,8 @@
+import { useIsFocused } from '@react-navigation/native'
+import { StatusBar, StatusBarProps } from 'expo-status-bar'
+
+const FocusAwareStatusBar = (props: StatusBarProps) => {
+  return useIsFocused() ? <StatusBar {...props} /> : undefined
+}
+
+export default FocusAwareStatusBar


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Breaking
- [ ] Documentation Update

## What?

*Describe the purpose of this pull request, i.e. brief description.*

This component, wraps the status bar component and makes it aware of screen focus so it can render only when the screen is focused. Since we are using Tabs, all screens are rendered at once and will be kept rendered - that means the last StatusBar config you set will be used. With the focus aware property, the status bar styling can be changed dynamically only when the relevant screen is rendered.

Important for reels as the status bar style should be `light` in the reels screen (and not light for everything else).

## How?

*Describe the changes made, i.e. implementation details.*

Uses react navigation to determine what is focused and renders the status bar, otherwise does not.

Reference: https://reactnavigation.org/docs/status-bar/

## Testing?

*Describe how the feature has been tested.*

| **Devices tested on** | **Code coverage** |
|-|-|
| iPhone15 | FocusAwareStatusBar.tsx  \|     100 \|      100 \|     100 \|     100 \|  |

## Screenshots/Video (optional)

*Include screenshots or video demonstrating the new feature, if applicable.*

Notice how the status bar changes color depending on the tab.

https://github.com/user-attachments/assets/d64f0f56-e6fd-4498-941a-3e558dc86959